### PR TITLE
Adds mwe2 packages as dependencies

### DIFF
--- a/org.emoflon.ibex.ide.feature/feature.xml
+++ b/org.emoflon.ibex.ide.feature/feature.xml
@@ -27,9 +27,9 @@
 
    <requires>
       <import feature="net.sourceforge.plantuml.feature" version="1.1.24"/>
-      <import feature="org.eclipse.emf.mwe2.launcher" version="2.12.1.v20210218-2134" match="greaterOrEqual"/>
-      <import feature="org.eclipse.emf.mwe2.runtime.sdk" version="2.12.1.v20210218-2134" match="greaterOrEqual"/>
-      <import feature="org.eclipse.emf.mwe2.language.sdk" version="2.12.1.v20210218-2134" match="greaterOrEqual"/>
+      <import feature="org.eclipse.emf.mwe2.launcher" version="2.12.1.v20210218-2134"/>
+      <import feature="org.eclipse.emf.mwe2.runtime.sdk" version="2.12.1.v20210218-2134"/>
+      <import feature="org.eclipse.emf.mwe2.language.sdk" version="2.12.1.v20210218-2134"/>
    </requires>
 
    <plugin

--- a/org.emoflon.ibex.ide.feature/feature.xml
+++ b/org.emoflon.ibex.ide.feature/feature.xml
@@ -27,6 +27,9 @@
 
    <requires>
       <import feature="net.sourceforge.plantuml.feature" version="1.1.24"/>
+      <import feature="org.eclipse.emf.mwe2.launcher" version="2.12.1.v20210218-2134" match="greaterOrEqual"/>
+      <import feature="org.eclipse.emf.mwe2.runtime.sdk" version="2.12.1.v20210218-2134" match="greaterOrEqual"/>
+      <import feature="org.eclipse.emf.mwe2.language.sdk" version="2.12.1.v20210218-2134" match="greaterOrEqual"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
For setting up the **eMoflon-ibex test workspace**, some mwe2 plugins must be installed in Eclipse in order to run/execute *.mwe2 files. Normally, these packages will be installed via the modeling update site during the installation of Xtext, etc.

However, I've encountered the problem of missing the mwe2 plugins if all plug-ins get installed headlessly (see https://github.com/maxkratz/emoflon-eclipse-build).

There are two ways to resolve this:
* Manually install the mwe2 plug-ins in the CI scripts of the other repository, or ...
* Adding them to the list of dependencies.

This PR represents the second proposed solution.